### PR TITLE
URI 한글 인코딩 수정, 티셔츠 이름 변경 api 오류 수정

### DIFF
--- a/src/main/java/com/gamechanger/domain/Clothes.java
+++ b/src/main/java/com/gamechanger/domain/Clothes.java
@@ -15,6 +15,7 @@ import java.util.Map;
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/gamechanger/repository/ClothesRepository.java
+++ b/src/main/java/com/gamechanger/repository/ClothesRepository.java
@@ -13,7 +13,4 @@ public interface ClothesRepository extends JpaRepository<Clothes, String> {
     Optional<Clothes> findByClothesName(String clothesName);
     @Transactional
     void deleteBySystemClothesId(Long systemClothesId);
-    @Modifying
-    @Query("UPDATE Clothes c SET c.clothesName = :newClothesName WHERE c.systemClothesId = :systemClothesId")
-    void changeClothesName(Long systemClothesId, String newClothesName);
 }

--- a/src/main/java/com/gamechanger/service/clothes/ClothesServiceImpl.java
+++ b/src/main/java/com/gamechanger/service/clothes/ClothesServiceImpl.java
@@ -5,6 +5,9 @@ import com.gamechanger.domain.Image;
 import com.gamechanger.domain.User;
 import com.gamechanger.repository.ClothesRepository;
 import com.gamechanger.service.image.ImageService;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.json.simple.parser.ParseException;
@@ -78,9 +81,10 @@ public class ClothesServiceImpl implements ClothesService {
 
     @Override
     public Clothes changeClothesName(Long systemClothesId, String newClothesName) {
-        clothesRepository.changeClothesName(systemClothesId, newClothesName);
-        Optional<Clothes> changedClothes = clothesRepository.findByClothesName(newClothesName);
-        return changedClothes.orElse(null);
+        Clothes clothes = clothesRepository.findBySystemClothesId(systemClothesId)
+                .orElseThrow(() -> new EntityNotFoundException("Clothes not found"));
+        clothes.setClothesName(newClothesName);
+        return clothesRepository.save(clothes);
     }
 
     @Override

--- a/src/main/java/com/gamechanger/util/UrlUtils.java
+++ b/src/main/java/com/gamechanger/util/UrlUtils.java
@@ -1,0 +1,10 @@
+package com.gamechanger.util;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+public class UrlUtils {
+    public static String UrlDecode(String original) {
+        return URLDecoder.decode(original, StandardCharsets.UTF_8);
+    }
+}


### PR DESCRIPTION
### URI 한글 인코딩
- 티셔츠 이름이 한글일 때 URI가 /clothes/name/%E0~~이런 식으로 반환되는데, 이 경로로 들어와도 한글로 받을 수 있게 함
- 티셔츠 이름 변경 시에 바뀐 티셔츠 이름에 대한 URI 반환하도록 변경
### 티셔츠 이름 변경 api
- db의 영속성 문제로 인해 db에는 반영되지만, 반환되는 객체의 이름이 바뀌지 않았음