### PR TITLE
티셔츠 이름 변경 기능 오류 수정, 엔티티의 필요 없는 멤버 삭제

### DIFF
--- a/src/main/java/com/gamechanger/domain/Clothes.java
+++ b/src/main/java/com/gamechanger/domain/Clothes.java
@@ -28,12 +28,6 @@ public class Clothes {
     @NotNull
     private String clothesName;
     private String roomId;
-    @Column(length = 10)
-    @NotNull
-    private String shape;   // 기본 : 반팔 char나 int로 바이트 수 줄여도 됨
-    @Column(length = 20)
-    @NotNull
-    private String background;
 
     @CreatedDate
     @Column(updatable = false)
@@ -63,8 +57,6 @@ public class Clothes {
         StringBuilder str = new StringBuilder("Clothes{" +
                 "clothesName='" + clothesName + '\'' +
                 ", userLoginId='" + user.getLoginId() + '\'' +
-                ", shape='" + shape + '\'' +
-                ", background='" + background + '\'' +
                 ", fileList.size()='" + imageFileList.size() + '\'');
         for (int i = 0; i < imageFileList.size(); i++) {
             str.append(", image ").append(i).append("= ").append(imageFileList.get(i).toString());

--- a/src/main/java/com/gamechanger/domain/Image.java
+++ b/src/main/java/com/gamechanger/domain/Image.java
@@ -19,13 +19,6 @@ public class Image {
     private String fileName;
     @NotNull
     private String fileUrl;
-    @NotNull
-    private double locationX;
-    @NotNull
-    private double locationY;
-    @Column(length = 10)
-    @NotNull
-    private String view;
 
     @JsonIgnore
     @ManyToOne
@@ -41,9 +34,6 @@ public class Image {
     public String toString() {
         return "Image{" +
                 ", fileUrl='" + fileUrl + '\'' +
-                ", locationY=" + locationY +
-                ", locationX=" + locationX +
-                ", view='" + view + '\'' +
                 ", clothesName='" + clothes.getClothesName() + '\'' +
                 '}';
     }

--- a/src/main/java/com/gamechanger/service/clothes/ClothesServiceImpl.java
+++ b/src/main/java/com/gamechanger/service/clothes/ClothesServiceImpl.java
@@ -5,9 +5,7 @@ import com.gamechanger.domain.Image;
 import com.gamechanger.domain.User;
 import com.gamechanger.repository.ClothesRepository;
 import com.gamechanger.service.image.ImageService;
-import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
-import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.json.simple.parser.ParseException;
@@ -35,11 +33,12 @@ public class ClothesServiceImpl implements ClothesService {
                 .user(user)
                 .build();
         String[] defaultAccesses = {"room:write"};
+        Clothes savedClothes = clothesRepository.save(clothes);
         String responseRoomId = liveblocksService.createRoom(clothes.getRoomId(), defaultAccesses);
         // 룸 생성은 컨트롤러에서 하던지, save를 먼저 하던지 해야 할 듯?
         // NotNull이나 컬럼 길이 제한 같은게 레포에 save할 때 검사하는 것 같은데, 룸을 먼저 생성하니까 룸은 생성되고 옷은 생성 안되게 됨.
         log.info("Clothes Name: {}, Room Id: {} created.", clothesName, responseRoomId);
-        return clothesRepository.save(clothes);
+        return savedClothes;
     }
 
     @Override
@@ -84,7 +83,8 @@ public class ClothesServiceImpl implements ClothesService {
         Clothes clothes = clothesRepository.findBySystemClothesId(systemClothesId)
                 .orElseThrow(() -> new EntityNotFoundException("Clothes not found"));
         clothes.setClothesName(newClothesName);
-        return clothesRepository.save(clothes);
+        clothesRepository.save(clothes);
+        return clothesRepository.findBySystemClothesId(systemClothesId).orElse(null);
     }
 
     @Override

--- a/src/main/java/com/gamechanger/service/clothes/ClothesServiceImpl.java
+++ b/src/main/java/com/gamechanger/service/clothes/ClothesServiceImpl.java
@@ -27,8 +27,6 @@ public class ClothesServiceImpl implements ClothesService {
         Clothes clothes = Clothes.builder()
                 .clothesName(clothesName)
                 .roomId(String.valueOf(UUID.randomUUID()))
-                .background("white")
-                .shape("half")
                 .imageFileList(new HashMap<>())
                 .user(user)
                 .build();
@@ -68,7 +66,11 @@ public class ClothesServiceImpl implements ClothesService {
 
     @Override
     public void deleteClothes(Long systemClothesId) {
-        Clothes clothes = clothesRepository.findBySystemClothesId(systemClothesId).get();
+        Optional<Clothes> optionalClothes = clothesRepository.findBySystemClothesId(systemClothesId);
+        if (optionalClothes.isEmpty()) {
+            return;
+        }
+        Clothes clothes = optionalClothes.get();
         for (Image image : clothes.getImageFileList().values()) {
             imageService.deleteImage(image.getFileName());
         }
@@ -89,7 +91,11 @@ public class ClothesServiceImpl implements ClothesService {
 
     @Override
     public Image uploadUserImage(Long systemClothesId, MultipartFile uploadImage, String clothesName) throws IOException {
-        Clothes clothes = clothesRepository.findBySystemClothesId(systemClothesId).get();
+        Optional<Clothes> optionalClothes = clothesRepository.findBySystemClothesId(systemClothesId);
+        if (optionalClothes.isEmpty()) {
+            return null;
+        }
+        Clothes clothes = optionalClothes.get();
         Image uploadedImage = imageService.uploadImage(clothes, uploadImage.getBytes(), "front");
         clothes.addImageFile(uploadedImage);
         return uploadedImage;
@@ -97,7 +103,11 @@ public class ClothesServiceImpl implements ClothesService {
 
     @Override
     public Image createAiImageByPrompt(Long systemClothesId, String clothesName, String style, String prompt) {
-        Clothes clothes = clothesRepository.findBySystemClothesId(systemClothesId).get();
+        Optional<Clothes> optionalClothes = clothesRepository.findBySystemClothesId(systemClothesId);
+        if (optionalClothes.isEmpty()) {
+            return null;
+        }
+        Clothes clothes = optionalClothes.get();
         Image aiImageByPrompt = imageService.createAiImageByPrompt(clothes, style, prompt);
         clothes.addImageFile(aiImageByPrompt);
         return aiImageByPrompt;
@@ -105,7 +115,11 @@ public class ClothesServiceImpl implements ClothesService {
 
     @Override
     public Image removeImageBackground(Long systemClothesId, String clothesName, String fileUrl) {
-        Clothes clothes = clothesRepository.findBySystemClothesId(systemClothesId).get();
+        Optional<Clothes> optionalClothes = clothesRepository.findBySystemClothesId(systemClothesId);
+        if (optionalClothes.isEmpty()) {
+            return null;
+        }
+        Clothes clothes = optionalClothes.get();
         Image removedImage = imageService.removeImageBackground(clothes, fileUrl);
         clothes.addImageFile(removedImage);
         return removedImage;

--- a/src/main/java/com/gamechanger/service/image/ImageServiceImpl.java
+++ b/src/main/java/com/gamechanger/service/image/ImageServiceImpl.java
@@ -49,9 +49,6 @@ public class ImageServiceImpl implements ImageService {
         return imageRepository.save(Image.builder()
                 .fileName(FileUtils.getFileNameFromUrl(fileUrl))
                 .fileUrl(fileUrl)
-                .view(view)
-                .locationX(0.0f)    // 기본값. 중앙으로 설정하기. 프론트에서 전달해야 한다면 인자로 전달받기
-                .locationY(0.0f)
                 .clothes(clothes)
                 .build());
     }


### PR DESCRIPTION
### 티셔츠 이름 변경 오류
- modifiedAt 멤버가 수정되지 않고 반환되는 현상
- 저장하고 다시 해당 멤버를 db에서 찾아서 반환함으로 해결
### 엔티티 멤버 수정
- 티셔츠 색, 이미지 좌표 등 캔버스 상의 데이터 삭제
- Liveblocks API에서 관리함