### PR TITLE
fix: 티셔츠 삭제 시 이미지 여러 개이면 ConcurrentModificationException 발생

### DIFF
--- a/src/main/java/com/gamechanger/repository/ImageRepository.java
+++ b/src/main/java/com/gamechanger/repository/ImageRepository.java
@@ -1,11 +1,22 @@
 package com.gamechanger.repository;
 
 import com.gamechanger.domain.Image;
+import feign.Param;
 import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface ImageRepository extends JpaRepository<Image, String> {
     Image findByFileName(String fileName);
+    @Query("SELECT i FROM Image i WHERE i.clothes.systemClothesId = :systemClothesId")
+    List<Image> findImagesBySystemClothesId(@Param("systemClothesId") Long systemClothesId);
     @Transactional
     void deleteByFileName(String fileName);
+    @Transactional
+    @Modifying
+    @Query("DELETE FROM Image i WHERE i.clothes.systemClothesId = :systemClothesId")
+    void deleteImagesBySystemClothesId(@Param("systemClothesId") Long systemClothesId);
 }

--- a/src/main/java/com/gamechanger/service/clothes/ClothesServiceImpl.java
+++ b/src/main/java/com/gamechanger/service/clothes/ClothesServiceImpl.java
@@ -71,9 +71,7 @@ public class ClothesServiceImpl implements ClothesService {
             return;
         }
         Clothes clothes = optionalClothes.get();
-        for (Image image : clothes.getImageFileList().values()) {
-            imageService.deleteImage(image.getFileName());
-        }
+        imageService.deleteAllImage(clothes);
         String roomId = clothes.getRoomId();
         liveblocksService.deleteRoom(roomId);
         clothesRepository.deleteBySystemClothesId(systemClothesId);

--- a/src/main/java/com/gamechanger/service/image/ImageService.java
+++ b/src/main/java/com/gamechanger/service/image/ImageService.java
@@ -13,4 +13,5 @@ public interface ImageService {
     Image getImage(String fileUrl);
     Image updateImage(Image Image);
     void deleteImage(String fileName);
+    void deleteAllImage(Clothes clothes);
 }

--- a/src/main/java/com/gamechanger/service/image/ImageServiceImpl.java
+++ b/src/main/java/com/gamechanger/service/image/ImageServiceImpl.java
@@ -11,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 @Slf4j
 @RequiredArgsConstructor
 public class ImageServiceImpl implements ImageService {
@@ -70,5 +72,15 @@ public class ImageServiceImpl implements ImageService {
         Image image = imageRepository.findByFileName(fileName);
         image.removeImageFromClothes();
         imageRepository.deleteByFileName(fileName);
+    }
+
+    @Override
+    public void deleteAllImage(Clothes clothes) {
+        Long clothesId = clothes.getSystemClothesId();
+        List<Image> deletingImages = imageRepository.findImagesBySystemClothesId(clothesId);
+        for (Image image : deletingImages) {
+            fileService.deleteFile(image.getFileName());
+        }
+        imageRepository.deleteImagesBySystemClothesId(clothesId);
     }
 }


### PR DESCRIPTION
- 기존의 티셔츠의 모든 이미지 삭제하는 메커니즘은 Map에 동시에 삭제를 시도할 수 있었음
- 쿼리를 이용해 DB에서 같은 Clothes와 연결된 이미지들을 모두 삭제하도록 수정